### PR TITLE
Update application environment variables

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 # whether or not the app runs in sandbox mode
-config :feedly, sandbox: true
-config :feedly, client_id: "sandbox"
-config :feedly, client_secret: "4205DQXBAP99S8SUHXI3" # (expires on 6/1/2015)
-config :feedly, redirect_uri: "http://localhost:8080/" # don't forget the closing "/"
+config :feedlex, sandbox: true
+config :feedlex, client_id: "sandbox"
+config :feedlex, client_secret: "JSSBD6FZT72058P51XEG" # (expires on 4/1/2016)
+config :feedlex, redirect_uri: "http://localhost:8080/" # don't forget the closing "/"

--- a/lib/feedlex/auth.ex
+++ b/lib/feedlex/auth.ex
@@ -16,8 +16,8 @@ defmodule Feedlex.Auth do
   def authenticate_uri(opts \\ %{}) do
     uri = Feedlex.feedly_api_host[opts[:env] || :sandbox] <> @feedly_auth_uri <> "?" <>
             "response_type=#{opts[:response_type] || "code"}" <> "&" <>
-            "client_id=#{opts[:client_id] || Application.get_env(:feedly, :client_id)}" <> "&" <>
-            "redirect_uri=#{URI.encode_www_form(opts[:redirect_uri] || Application.get_env(:feedly, :redirect_uri))}" <> "&" <>
+            "client_id=#{opts[:client_id] || Application.get_env(:feedlex, :client_id)}" <> "&" <>
+            "redirect_uri=#{URI.encode_www_form(opts[:redirect_uri] || Application.get_env(:feedlex, :redirect_uri))}" <> "&" <>
             "scope=#{opts[:scope] || "https://cloud.feedly.com/subscriptions"}"
     unless is_nil(opts[:state]), do: uri = uri <> "&state=#{URI.encode_www_form(opts[:state])}"
 
@@ -32,15 +32,15 @@ defmodule Feedlex.Auth do
     payload = ~s"""
     {
       "code":"#{opts[:code]}",
-      "client_id":"#{opts[:client_id] || Application.get_env(:feedly, :client_id)}",
-      "client_secret":"#{opts[:client_secret] || Application.get_env(:feedly, :client_secret)}",
+      "client_id":"#{opts[:client_id] || Application.get_env(:feedlex, :client_id)}",
+      "client_secret":"#{opts[:client_secret] || Application.get_env(:feedlex, :client_secret)}",
       "state":"#{URI.encode_www_form(opts[:state] || "")}",
       "grant_type":"#{opts[:grant_type] || "authorization_code"}"
     }
     """
 
     uri = Feedlex.feedly_api_host[opts[:env] || :sandbox] <> @feedly_auth_token_uri <> "?" <>
-            "redirect_uri=#{URI.encode_www_form(opts[:redirect_uri] || Application.get_env(:feedly, :redirect_uri))}"
+            "redirect_uri=#{URI.encode_www_form(opts[:redirect_uri] || Application.get_env(:feedlex, :redirect_uri))}"
 
     HTTPoison.start
     HTTPoison.post!(uri, payload, @request_headers_json)
@@ -54,8 +54,8 @@ defmodule Feedlex.Auth do
     payload = ~s"""
     {
       "refresh_token":"#{opts[:refresh_token]}",
-      "client_id":"#{opts[:client_id] || Application.get_env(:feedly, :client_id)}",
-      "client_secret":"#{opts[:client_secret] || Application.get_env(:feedly, :client_secret)}",
+      "client_id":"#{opts[:client_id] || Application.get_env(:feedlex, :client_id)}",
+      "client_secret":"#{opts[:client_secret] || Application.get_env(:feedlex, :client_secret)}",
       "grant_type":"refresh_token"
     }
     """
@@ -74,8 +74,8 @@ defmodule Feedlex.Auth do
     payload = ~s"""
     {
       "refresh_token":"#{opts[:refresh_token]}",
-      "client_id":"#{opts[:client_id] || Application.get_env(:feedly, :client_id)}",
-      "client_secret":"#{opts[:client_secret] || Application.get_env(:feedly, :client_secret)}",
+      "client_id":"#{opts[:client_id] || Application.get_env(:feedlex, :client_id)}",
+      "client_secret":"#{opts[:client_secret] || Application.get_env(:feedlex, :client_secret)}",
       "grant_type":"revoke_token"
     }
     """

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Feedlex.Mixfile do
 
   def project do
     [app: :feedlex,
-     version: "0.0.2",
+     version: "0.0.3",
      deps_path: "../../deps",
      lockfile: "../../mix.lock",
      elixir: "~> 1.0",


### PR DESCRIPTION
Updated `:feedly` to `:feedlex` which is the proper application name so we can define our Feedly API keys in our `config/dev.exs`.

Also updated to the latest Feedly API sandbox key from their mailing list.